### PR TITLE
Update RSpec version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,11 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in rdf-virtuoso.gemspec
 gemspec
+
+gem "rdf",            git: "git://github.com/ruby-rdf/rdf.git", branch: "develop"
+
+group :development, :test do
+  gem "rdf-spec",     git: "git://github.com/ruby-rdf/rdf-spec.git", branch: "develop"
+  gem "rdf-vocab",    git: "git://github.com/ruby-rdf/rdf-vocab.git", branch: "develop"
+  gem "wirble"
+end

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ This example assumes you have a local installation of Virtoso running at standar
     uri        = "http://localhost:8890/sparql"
     update_uri = "http://localhost:8890/sparql-auth"
     repo       = RDF::Virtuoso::Repository.new(uri, 
-                    :update_uri => update_uri, 
-                    :username => 'admin', 
-                    :password => 'secret', 
-                    :auth_method => 'digest')
+                    update_uri: update_uri, 
+                    username: 'admin', 
+                    password: 'secret', 
+                    auth_method: 'digest')
 
 :auth_method can be 'digest' or 'basic'. a repository connection without auth requires only uri
 

--- a/lib/rdf/virtuoso/parser.rb
+++ b/lib/rdf/virtuoso/parser.rb
@@ -29,9 +29,9 @@ module RDF
           when :uri
             RDF::URI.new(value['value'])
           when :literal
-            RDF::Literal.new(value['value'], :language => value['xml:lang'])
+            RDF::Literal.new(value['value'], language: value['xml:lang'])
           when :'typed-literal'
-            RDF::Literal.new(value['value'], :datatype => value['datatype'])
+            RDF::Literal.new(value['value'], datatype: value['datatype'])
           else nil
           end
         end    

--- a/lib/rdf/virtuoso/query.rb
+++ b/lib/rdf/virtuoso/query.rb
@@ -414,7 +414,7 @@ module RDF::Virtuoso
     ##
     # @private 
     # make RDF::Query::Pattern from triple array if not already done
-    # include :context in Statement
+    # include :graph_name in Statement
     # @return [RDF::Query::Pattern]
     def build_patterns(patterns)
       patterns.map do |pattern|
@@ -603,10 +603,10 @@ module RDF::Virtuoso
         buffer << '{' if options[:unions]
 
         # iterate patterns
-        # does patterns have :context hash? build with GRAPH statement
+        # does patterns have :graph_name hash? build with GRAPH statement
         patterns.each do | pattern|
-          if pattern.context
-            buffer << "GRAPH #{serialize_value(RDF::URI(pattern.context))}"
+          if pattern.graph_name
+            buffer << "GRAPH #{serialize_value(RDF::URI(pattern.graph_name))}"
             buffer << '{'
             buffer << serialize_patterns(pattern)
             buffer << '}'
@@ -620,8 +620,8 @@ module RDF::Virtuoso
             buffer << 'OPTIONAL {'
 
 	        patterns.each do | pattern|
-          if pattern.context
-            buffer << "GRAPH #{serialize_value(RDF::URI(pattern.context))}"
+          if pattern.graph_name
+            buffer << "GRAPH #{serialize_value(RDF::URI(pattern.graph_name))}"
             buffer << '{'
             buffer << serialize_patterns(pattern)
             buffer << '}'
@@ -639,8 +639,8 @@ module RDF::Virtuoso
             buffer << 'MINUS {'
 
 	        patterns.each do | pattern|
-          if pattern.context
-            buffer << "GRAPH #{serialize_value(RDF::URI(pattern.context))}"
+          if pattern.graph_name
+            buffer << "GRAPH #{serialize_value(RDF::URI(pattern.graph_name))}"
             buffer << '{'
             buffer << serialize_patterns(pattern)
             buffer << '}'

--- a/lib/rdf/virtuoso/repository.rb
+++ b/lib/rdf/virtuoso/repository.rb
@@ -73,24 +73,24 @@ module RDF
       end
 
       def base_query_options
-        { :format => RESULT_JSON }
+        { format: RESULT_JSON }
       end
 
       def base_request_options
-        { :headers => headers }
+        { headers: headers }
       end
 
       def extra_request_options
         case @auth_method
         when 'basic'
-          { :basic_auth => auth }
+          { basic_auth: auth }
         when 'digest'
-          { :digest_auth => auth }
+          { digest_auth: auth }
         end
       end
 
       def auth
-        { :username => @username, :password => @password }
+        { username: @username, password: @password }
       end
 
       def api_get(query, options = {})
@@ -98,16 +98,16 @@ module RDF
         if @sparul_endpoint
           self.class.endpoint @sparul_endpoint
           Timeout::timeout(@timeout) {
-            get '/', :extra_query => { :query => query }.merge(options),
-                     :extra_request => extra_request_options,
-                     :transform => RDF::Virtuoso::Parser::JSON
+            get '/', extra_query: { query: query }.merge(options),
+                     extra_request: extra_request_options,
+                     transform: RDF::Virtuoso::Parser::JSON
           }
         else
           self.class.endpoint @sparql_endpoint
           Timeout::timeout(@timeout) {
           puts self.inspect
-            get '/', :extra_query => { :query => query }.merge(options),
-                     :transform => RDF::Virtuoso::Parser::JSON
+            get '/', extra_query: { query: query }.merge(options),
+                     transform: RDF::Virtuoso::Parser::JSON
           }
         end
       end
@@ -115,9 +115,9 @@ module RDF
       def api_post(query, options = {})
         self.class.endpoint @sparul_endpoint
         Timeout::timeout(@timeout) {
-          post '/', :extra_body => { :query => query }.merge(options),
-                    :extra_request => extra_request_options,
-                    :response_container => [
+          post '/', extra_body: { query: query }.merge(options),
+                    extra_request: extra_request_options,
+                    response_container: [
                       "results", "bindings", 0, "callret-0", "value"]
         }
       end

--- a/rdf-virtuoso.gemspec
+++ b/rdf-virtuoso.gemspec
@@ -19,10 +19,11 @@ Gem::Specification.new do |s|
   s.files        += Dir['spec/**/*.rb'] + Dir['doc/**/**/*.rb']
   s.require_paths = ['lib']
 
-  s.add_development_dependency 'rspec', '~> 2.14.1'
-  s.add_development_dependency 'rdf-spec', '~> 1.1.0'
+  s.add_development_dependency 'rspec', '~> 3.2'
+  s.add_development_dependency 'rdf-spec', '~> 1.1'
+  s.add_development_dependency 'rdf-vocab', '~> 0.8'
 
-  s.add_runtime_dependency 'rdf', '~> 1.1.0'
+  s.add_runtime_dependency 'rdf', '>= 1.99'
   s.add_runtime_dependency 'httparty', '~> 0.12.0'
   s.add_runtime_dependency 'api_smith', '~> 1.3.0'
 

--- a/spec/prefixes_spec.rb
+++ b/spec/prefixes_spec.rb
@@ -5,43 +5,43 @@ describe RDF::Virtuoso::Prefixes do
   subject { RDF::Virtuoso::Prefixes.new(foo: 'bar', baz: 'quux') }
 
   it "takes a hash when initialized" do
-    subject.should be_a RDF::Virtuoso::Prefixes
+    is_expected.to be_a RDF::Virtuoso::Prefixes
   end
 
   it "responds to to_a" do
-    subject.should respond_to :to_a
+    is_expected.to respond_to :to_a
   end
 
   it "returns a nice array" do
-    subject.to_a.should == ["foo: <bar>", "baz: <quux>"]
+    expect(subject.to_a).to include("foo: <bar>", "baz: <quux>")
   end
 
   it "presents itself nicely" do
-    subject.to_s.should == "{:foo=>\"bar\", :baz=>\"quux\"}"
+    expect(subject.to_s).to eql "{:foo=>\"bar\", :baz=>\"quux\"}"
   end
 
   context "when creating prefixes" do
-    let(:uris) { [RDF::DC.title.to_s, "http://example.org/foo/bar", "http://hash.org/foo#bar"] }
+    let(:uris) { [RDF::Vocab::DC.title.to_s, "http://example.org/foo/bar", "http://hash.org/foo#bar"] }
 
     it "creates prefixes from uris" do
-      RDF::Virtuoso::Prefixes.parse(uris).should == [
+      expect(RDF::Virtuoso::Prefixes.parse(uris)).to include(
         "purl: <http://purl.org/dc/terms/>", 
         "example: <http://example.org/foo/>", 
         "hash: <http://hash.org/foo#>"
-      ]
+      )
     end
 
     it "only creates unique prefixes from uris" do
       uris << 'http://example.org/foo/baz'
-      RDF::Virtuoso::Prefixes.parse(uris).should == [
+      expect(RDF::Virtuoso::Prefixes.parse(uris)).to include(
         "purl: <http://purl.org/dc/terms/>", 
         "example: <http://example.org/foo/>", 
         "hash: <http://hash.org/foo#>"
-      ]
+      )
     end
 
     it "returns an error object if a disallowed param is sent" do
-      RDF::Virtuoso::Prefixes.parse({}).should be_a RDF::Virtuoso::UnProcessable
+      expect(RDF::Virtuoso::Prefixes.parse({})).to be_a RDF::Virtuoso::UnProcessable
     end
 
   end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -1,108 +1,105 @@
 require File.join(File.dirname(__FILE__), 'spec_helper')
 
 describe RDF::Virtuoso::Query do
-  before :each do
-    @query = RDF::Virtuoso::Query
-  end
+  subject {RDF::Virtuoso::Query}
 
   context "when building queries" do
     it "should support ASK queries" do
-      @query.should respond_to(:ask)
+      is_expected.to respond_to(:ask)
     end
 
     it "should support SELECT queries" do
-      @query.should respond_to(:select)
+      is_expected.to respond_to(:select)
     end
 
     it "should support DESCRIBE queries" do
-      @query.should respond_to(:describe)
+      is_expected.to respond_to(:describe)
     end
 
     it "should support CONSTRUCT queries" do
-      @query.should respond_to(:construct)
+      is_expected.to respond_to(:construct)
     end
 
     it "should support INSERT DATA queries" do
-      @query.should respond_to(:insert_data)
+      is_expected.to respond_to(:insert_data)
     end
 
     it "should support INSERT WHERE queries" do
-      @query.should respond_to(:insert)
+      is_expected.to respond_to(:insert)
     end
     
     it "should support DELETE DATA queries" do
-      @query.should respond_to(:delete_data)
+      is_expected.to respond_to(:delete_data)
     end
 
     it "should support DELETE WHERE queries" do
-      @query.should respond_to(:delete)
+      is_expected.to respond_to(:delete)
     end
 
     it "should support CREATE GRAPH queries" do
-      @query.should respond_to(:create)
+      is_expected.to respond_to(:create)
     end
 
   end
 
   context "when building update queries" do
-    before :each do
-      @graph = "http://example.org/"
-      @uri = RDF::Vocabulary.new "http://example.org/"
-    end
+    let(:graph) {"http://example.org/"}
+    let(:uri) {RDF::Vocabulary.new "http://example.org/"}
+
     # TODO add support for advanced inserts (moving copying between different graphs)
     it "should support INSERT DATA queries" do
-      @query.insert_data([@uri.ola, @uri.type, @uri.something]).graph(RDF::URI.new(@graph)).to_s.should == "INSERT DATA INTO GRAPH <#{@graph}> { <#{@graph}ola> <#{@graph}type> <#{@graph}something> . }"
-      @query.insert_data([@uri.ola, @uri.name, "two words"]).graph(RDF::URI.new(@graph)).to_s.should == "INSERT DATA INTO GRAPH <#{@graph}> { <#{@graph}ola> <#{@graph}name> \"two words\" . }"
+      expect(subject.insert_data([uri.ola, uri.type, uri.something]).graph(RDF::URI.new(graph)).to_s).to eql "INSERT DATA INTO GRAPH <#{graph}> { <#{graph}ola> <#{graph}type> <#{graph}something> . }"
+      expect(subject.insert_data([uri.ola, uri.name, "two words"]).graph(RDF::URI.new(graph)).to_s).to eql "INSERT DATA INTO GRAPH <#{graph}> { <#{graph}ola> <#{graph}name> \"two words\" . }"
     end
 
     it "should support INSERT DATA queries with arrays" do
-      @query.insert_data([@uri.ola, @uri.type, @uri.something],[@uri.ola, @uri.type, @uri.something_else]).graph(RDF::URI.new(@graph)).to_s.should == "INSERT DATA INTO GRAPH <#{@graph}> { <#{@graph}ola> <#{@graph}type> <#{@graph}something> . <#{@graph}ola> <#{@graph}type> <#{@graph}something_else> . }"
+      expect(subject.insert_data([uri.ola, uri.type, uri.something],[uri.ola, uri.type, uri.somethingElse]).graph(RDF::URI.new(graph)).to_s).to eql "INSERT DATA INTO GRAPH <#{graph}> { <#{graph}ola> <#{graph}type> <#{graph}something> . <#{graph}ola> <#{graph}type> <#{graph}somethingElse> . }"
     end
     
     it "should support INSERT DATA queries with RDF::Statements" do
       statements = [RDF::Statement.new(RDF::URI('http://test'), RDF.type, RDF::URI('http://type')), RDF::Statement.new(RDF::URI('http://test'), RDF.type, RDF::URI('http://type2'))]
-      @query.insert_data(statements).graph(RDF::URI.new(@graph)).to_s.should == "INSERT DATA INTO GRAPH <#{@graph}> { <http://test> <#{RDF.type}> <http://type> .\n <http://test> <#{RDF.type}> <http://type2> .\n }"
+      expect(subject.insert_data(statements).graph(RDF::URI.new(graph)).to_s).to eql "INSERT DATA INTO GRAPH <#{graph}> { <http://test> <#{RDF.type}> <http://type> .\n <http://test> <#{RDF.type}> <http://type2> .\n }"
     end
     
     it "should support INSERT WHERE queries with symbols and patterns" do
-      @query.insert([:s, :p, :o]).graph(RDF::URI.new(@graph)).where([:s, :p, :o]).to_s.should == "INSERT INTO GRAPH <#{@graph}> { ?s ?p ?o . } WHERE { ?s ?p ?o . }"
-      @query.insert([:s, @uri.newtype, :o]).graph(RDF::URI.new(@graph)).where([:s, @uri.type, :o]).to_s.should == "INSERT INTO GRAPH <#{@graph}> { ?s <#{@graph}newtype> ?o . } WHERE { ?s <#{@graph}type> ?o . }"
+      expect(subject.insert([:s, :p, :o]).graph(RDF::URI.new(graph)).where([:s, :p, :o]).to_s).to eql "INSERT INTO GRAPH <#{graph}> { ?s ?p ?o . } WHERE { ?s ?p ?o . }"
+      expect(subject.insert([:s, uri.newtype, :o]).graph(RDF::URI.new(graph)).where([:s, uri.type, :o]).to_s).to eql "INSERT INTO GRAPH <#{graph}> { ?s <#{graph}newtype> ?o . } WHERE { ?s <#{graph}type> ?o . }"
     end
 
     it "should support DELETE DATA queries" do
-      @query.delete_data([@uri.ola, @uri.type, @uri.something]).graph(RDF::URI.new(@graph)).to_s.should == "DELETE DATA FROM <#{@graph}> { <#{@graph}ola> <#{@graph}type> <#{@graph}something> . }"  
-      @query.delete_data([@uri.ola, @uri.name, RDF::Literal.new("myname")]).graph(RDF::URI.new(@graph)).to_s.should == "DELETE DATA FROM <#{@graph}> { <#{@graph}ola> <#{@graph}name> \"myname\" . }"  
+      expect(subject.delete_data([uri.ola, uri.type, uri.something]).graph(RDF::URI.new(graph)).to_s).to eql "DELETE DATA FROM <#{graph}> { <#{graph}ola> <#{graph}type> <#{graph}something> . }"  
+      expect(subject.delete_data([uri.ola, uri.name, RDF::Literal.new("myname")]).graph(RDF::URI.new(graph)).to_s).to eql "DELETE DATA FROM <#{graph}> { <#{graph}ola> <#{graph}name> \"myname\" . }"  
     end
 
     it "should support DELETE DATA queries with arrays" do
-      @query.delete_data([@uri.ola, @uri.type, @uri.something],[@uri.ola, @uri.type, @uri.something_else]).graph(RDF::URI.new(@graph)).to_s.should == "DELETE DATA FROM <#{@graph}> { <#{@graph}ola> <#{@graph}type> <#{@graph}something> . <#{@graph}ola> <#{@graph}type> <#{@graph}something_else> . }"
+      expect(subject.delete_data([uri.ola, uri.type, uri.something],[uri.ola, uri.type, uri.somethingElse]).graph(RDF::URI.new(graph)).to_s).to eql "DELETE DATA FROM <#{graph}> { <#{graph}ola> <#{graph}type> <#{graph}something> . <#{graph}ola> <#{graph}type> <#{graph}somethingElse> . }"
     end
     
     it "should support DELETE DATA queries with RDF::Statements" do
       statements = [RDF::Statement.new(RDF::URI('http://test'), RDF.type, RDF::URI('http://type')), RDF::Statement.new(RDF::URI('http://test'), RDF.type, RDF::URI('http://type2'))]
-      @query.delete_data(statements).graph(RDF::URI.new(@graph)).to_s.should == "DELETE DATA FROM <#{@graph}> { <http://test> <#{RDF.type}> <http://type> .\n <http://test> <#{RDF.type}> <http://type2> .\n }"
+      expect(subject.delete_data(statements).graph(RDF::URI.new(graph)).to_s).to eql "DELETE DATA FROM <#{graph}> { <http://test> <#{RDF.type}> <http://type> .\n <http://test> <#{RDF.type}> <http://type2> .\n }"
     end
 
     it "should support DELETE DATA queries with appendable objects" do
       statements = []
       statements << RDF::Statement.new(RDF::URI('http://test'), RDF.type, RDF::URI('http://type'))
       statements << RDF::Statement.new(RDF::URI('http://test'), RDF.type, RDF::URI('http://type2'))
-      @query.delete_data(statements).graph(RDF::URI.new(@graph)).to_s.should == "DELETE DATA FROM <#{@graph}> { <http://test> <#{RDF.type}> <http://type> .\n <http://test> <#{RDF.type}> <http://type2> .\n }"
+      expect(subject.delete_data(statements).graph(RDF::URI.new(graph)).to_s).to eql "DELETE DATA FROM <#{graph}> { <http://test> <#{RDF.type}> <http://type> .\n <http://test> <#{RDF.type}> <http://type2> .\n }"
     end
         
     it "should support DELETE WHERE queries with symbols and patterns" do
-      @query.delete([:s, :p, :o]).graph(RDF::URI.new(@graph)).where([:s, :p, :o]).to_s.should == "DELETE FROM <#{@graph}> { ?s ?p ?o . } WHERE { ?s ?p ?o . }"
-      @query.delete([:s, @uri.newtype, :o]).graph(RDF::URI.new(@graph)).where([:s, @uri.newtype, :o]).to_s.should == "DELETE FROM <#{@graph}> { ?s <#{@graph}newtype> ?o . } WHERE { ?s <#{@graph}newtype> ?o . }"
+      expect(subject.delete([:s, :p, :o]).graph(RDF::URI.new(graph)).where([:s, :p, :o]).to_s).to eql "DELETE FROM <#{graph}> { ?s ?p ?o . } WHERE { ?s ?p ?o . }"
+      expect(subject.delete([:s, uri.newtype, :o]).graph(RDF::URI.new(graph)).where([:s, uri.newtype, :o]).to_s).to eql "DELETE FROM <#{graph}> { ?s <#{graph}newtype> ?o . } WHERE { ?s <#{graph}newtype> ?o . }"
     end
 
     it "should support CREATE GRAPH queries" do
-      @query.create(RDF::URI.new(@graph)).to_s.should == "CREATE GRAPH <#{@graph}>"
-      @query.create(RDF::URI.new(@graph), :silent => true).to_s.should == "CREATE SILENT GRAPH <#{@graph}>"
+      expect(subject.create(RDF::URI.new(graph)).to_s).to eql "CREATE GRAPH <#{graph}>"
+      expect(subject.create(RDF::URI.new(graph), silent: true).to_s).to eql "CREATE SILENT GRAPH <#{graph}>"
     end
 
     it "should support DROP GRAPH queries" do
-      @query.drop(RDF::URI.new(@graph)).to_s.should == "DROP GRAPH <#{@graph}>"
-      @query.drop(RDF::URI.new(@graph), :silent => true).to_s.should == "DROP SILENT GRAPH <#{@graph}>"
+      expect(subject.drop(RDF::URI.new(graph)).to_s).to eql "DROP GRAPH <#{graph}>"
+      expect(subject.drop(RDF::URI.new(graph), silent: true).to_s).to eql "DROP SILENT GRAPH <#{graph}>"
 
     end
 
@@ -110,273 +107,292 @@ describe RDF::Virtuoso::Query do
 
   context "when building ASK queries" do
     it "should support basic graph patterns" do
-      @query.ask.where([:s, :p, :o]).to_s.should == "ASK WHERE { ?s ?p ?o . }"
-      @query.ask.whether([:s, :p, :o]).to_s.should == "ASK WHERE { ?s ?p ?o . }"
+      expect(subject.ask.where([:s, :p, :o]).to_s).to eql "ASK WHERE { ?s ?p ?o . }"
+      expect(subject.ask.whether([:s, :p, :o]).to_s).to eql "ASK WHERE { ?s ?p ?o . }"
     end
   end
 
   context "when building SELECT queries" do
     it "should support basic graph patterns" do
-      @query.select.where([:s, :p, :o]).to_s.should == "SELECT * WHERE { ?s ?p ?o . }"
+      expect(subject.select.where([:s, :p, :o]).to_s).to eql "SELECT * WHERE { ?s ?p ?o . }"
     end
 
     it "should support projection" do
-      @query.select(:s).where([:s, :p, :o]).to_s.should == "SELECT ?s WHERE { ?s ?p ?o . }"
-      @query.select(:s, :p).where([:s, :p, :o]).to_s.should == "SELECT ?s ?p WHERE { ?s ?p ?o . }"
-      @query.select(:s, :p, :o).where([:s, :p, :o]).to_s.should == "SELECT ?s ?p ?o WHERE { ?s ?p ?o . }"
+      expect(subject.select(:s).where([:s, :p, :o]).to_s).to eql "SELECT ?s WHERE { ?s ?p ?o . }"
+      expect(subject.select(:s, :p).where([:s, :p, :o]).to_s).to eql "SELECT ?s ?p WHERE { ?s ?p ?o . }"
+      expect(subject.select(:s, :p, :o).where([:s, :p, :o]).to_s).to eql "SELECT ?s ?p ?o WHERE { ?s ?p ?o . }"
     end
 
     it "should support SELECT FROM" do
-      @graph = RDF::URI("http://example.org/")
-      @query.select(:s).where([:s, :p, :o]).from(@graph).to_s.should == "SELECT ?s FROM <#{@graph}> WHERE { ?s ?p ?o . }"
+      graph = RDF::URI("http://example.org/")
+      expect(subject.select(:s).where([:s, :p, :o]).from(graph).to_s).to eql "SELECT ?s FROM <#{graph}> WHERE { ?s ?p ?o . }"
     end
 
     it "should support SELECT FROM and FROM NAMED" do
-      @graph1 = RDF::URI("a")
-      @graph2 = RDF::URI("b")
-      @query.select(:s).where([:s, :p, :o, :context => @graph2]).from(@graph1).from_named(@graph2).to_s.should ==
-        "SELECT ?s FROM <#{@graph1}> FROM NAMED <#{@graph2}> WHERE { GRAPH <#{@graph2}> { ?s ?p ?o . } }"
+      graph1 = RDF::URI("a")
+      graph2 = RDF::URI("b")
+      expect(subject.select(:s).where([:s, :p, :o, graph_name: graph2]).from(graph1).from_named(graph2).to_s).to eql(
+        "SELECT ?s FROM <#{graph1}> FROM NAMED <#{graph2}> WHERE { GRAPH <#{graph2}> { ?s ?p ?o . } }"
+      )
     end
 
     it "should support one SELECT FROM and multiple FROM NAMED" do
-      @graph1 = RDF::URI("a")
-      @graph2 = RDF::URI("b")
-      @graph3 = RDF::URI("c")
-      @query.select(:s).where([:s, :p, :o, :context => @graph2], [:s, :p, :o, :context => @graph3]).from(@graph1).from_named(@graph2).from_named(@graph3).to_s.should ==
-        "SELECT ?s FROM <#{@graph1}> FROM NAMED <#{@graph2}> FROM NAMED <#{@graph3}> WHERE { GRAPH <#{@graph2}> { ?s ?p ?o . } GRAPH <#{@graph3}> { ?s ?p ?o . } }"
+      graph1 = RDF::URI("a")
+      graph2 = RDF::URI("b")
+      graph3 = RDF::URI("c")
+      expect(subject.select(:s).where([:s, :p, :o, graph_name: graph2], [:s, :p, :o, graph_name: graph3]).from(graph1).from_named(graph2).from_named(graph3).to_s).to eql(
+        "SELECT ?s FROM <#{graph1}> FROM NAMED <#{graph2}> FROM NAMED <#{graph3}> WHERE { GRAPH <#{graph2}> { ?s ?p ?o . } GRAPH <#{graph3}> { ?s ?p ?o . } }"
+      )
     end
 
     it "should support SELECT with complex WHERE patterns" do
-      @query.select.where(
+      expect(subject.select.where(
       [:s, :p, :o],
-      [:s, RDF.type, RDF::DC.BibliographicResource]
-      ).to_s.should ==
-        "SELECT * WHERE { ?s ?p ?o . ?s <#{RDF.type}> <#{RDF::DC.BibliographicResource}> . }"
+      [:s, RDF.type, RDF::Vocab::DC.BibliographicResource]
+      ).to_s).to eql(
+        "SELECT * WHERE { ?s ?p ?o . ?s <#{RDF.type}> <#{RDF::Vocab::DC.BibliographicResource}> . }"
+      )
     end
 
-    it "should support SELECT WHERE patterns from different GRAPH contexts" do
-      @graph1 = "http://example1.org/"
-      @graph2 = "http://example2.org/"
-      @query.select.where([:s, :p, :o, :context => @graph1],[:s, RDF.type, RDF::DC.BibliographicResource, :context => @graph2]).to_s.should ==
-        "SELECT * WHERE { GRAPH <#{@graph1}> { ?s ?p ?o . } GRAPH <#{@graph2}> { ?s <#{RDF.type}> <#{RDF::DC.BibliographicResource}> . } }"
+    it "should support SELECT WHERE patterns from different GRAPH names" do
+      graph1 = "http://example1.org/"
+      graph2 = "http://example2.org/"
+      expect(subject.select.where([:s, :p, :o, graph_name: graph1],[:s, RDF.type, RDF::Vocab::DC.BibliographicResource, graph_name: graph2]).to_s).to eql(
+        "SELECT * WHERE { GRAPH <#{graph1}> { ?s ?p ?o . } GRAPH <#{graph2}> { ?s <#{RDF.type}> <#{RDF::Vocab::DC.BibliographicResource}> . } }"
+      )
     end
 
     it "should support string objects in SPARQL queries" do
-      @query.select.where([:s, :p, "dummyobject"]).to_s.should == "SELECT * WHERE { ?s ?p \"dummyobject\" . }"
+      expect(subject.select.where([:s, :p, "dummyobject"]).to_s).to eql "SELECT * WHERE { ?s ?p \"dummyobject\" . }"
     end
 
     #it "should support raw string SPARQL queries" do
     #  q = "SELECT * WHERE { ?s <#{RDF.type}> ?o . }"
-    #  @query.query(q).should == "SELECT * WHERE { ?s <#{RDF.type}> ?o . }"
+    #  expect(subject.query(q)).to eql "SELECT * WHERE { ?s <#{RDF.type}> ?o . }"
     #end
 
     it "should support FROM" do
       uri = "http://example.org/dft.ttl"
-      @query.select.from(RDF::URI.new(uri)).where([:s, :p, :o]).to_s.should ==
+      expect(subject.select.from(RDF::URI.new(uri)).where([:s, :p, :o]).to_s).to eql(
         "SELECT * FROM <#{uri}> WHERE { ?s ?p ?o . }"
+      )
     end
 
     it "should support DISTINCT" do
-      @query.select(:s, :distinct => true).where([:s, :p, :o]).to_s.should == "SELECT DISTINCT ?s WHERE { ?s ?p ?o . }"
-      @query.select(:s).distinct.where([:s, :p, :o]).to_s.should == "SELECT DISTINCT ?s WHERE { ?s ?p ?o . }"
+      expect(subject.select(:s, distinct: true).where([:s, :p, :o]).to_s).to eql "SELECT DISTINCT ?s WHERE { ?s ?p ?o . }"
+      expect(subject.select(:s).distinct.where([:s, :p, :o]).to_s).to eql "SELECT DISTINCT ?s WHERE { ?s ?p ?o . }"
     end
 
     it "should support REDUCED" do
-      @query.select(:s, :reduced => true).where([:s, :p, :o]).to_s.should == "SELECT REDUCED ?s WHERE { ?s ?p ?o . }"
-      @query.select(:s).reduced.where([:s, :p, :o]).to_s.should == "SELECT REDUCED ?s WHERE { ?s ?p ?o . }"
+      expect(subject.select(:s, reduced: true).where([:s, :p, :o]).to_s).to eql "SELECT REDUCED ?s WHERE { ?s ?p ?o . }"
+      expect(subject.select(:s).reduced.where([:s, :p, :o]).to_s).to eql "SELECT REDUCED ?s WHERE { ?s ?p ?o . }"
     end
 
     it "should support aggregate COUNT" do
-      @query.select.where([:s, :p, :o]).count(:s).to_s.should == "SELECT (COUNT (?s) AS ?s) WHERE { ?s ?p ?o . }"
-      @query.select.count(:s).where([:s, :p, :o]).to_s.should == "SELECT (COUNT (?s) AS ?s) WHERE { ?s ?p ?o . }"
+      expect(subject.select.where([:s, :p, :o]).count(:s).to_s).to eql "SELECT (COUNT (?s) AS ?s) WHERE { ?s ?p ?o . }"
+      expect(subject.select.count(:s).where([:s, :p, :o]).to_s).to eql "SELECT (COUNT (?s) AS ?s) WHERE { ?s ?p ?o . }"
     end
 
     it "should support aggregates SUM, MIN, MAX, AVG, SAMPLE, GROUP_CONCAT, GROUP_DIGEST" do
-      @query.select.where([:s, :p, :o]).sum(:s).to_s.should == "SELECT (SUM (?s) AS ?s) WHERE { ?s ?p ?o . }"
-      @query.select.where([:s, :p, :o]).min(:s).to_s.should == "SELECT (MIN (?s) AS ?s) WHERE { ?s ?p ?o . }"
-      @query.select.where([:s, :p, :o]).max(:s).to_s.should == "SELECT (MAX (?s) AS ?s) WHERE { ?s ?p ?o . }"
-      @query.select.where([:s, :p, :o]).avg(:s).to_s.should == "SELECT (AVG (?s) AS ?s) WHERE { ?s ?p ?o . }"
-      @query.select.where([:s, :p, :o]).sample(:s).to_s.should == "SELECT (sql:SAMPLE (?s) AS ?s) WHERE { ?s ?p ?o . }"
-      @query.select.where([:s, :p, :o]).group_concat(:s, '_').to_s.should == "SELECT (sql:GROUP_CONCAT (?s, '_' ) AS ?s) WHERE { ?s ?p ?o . }"
-      @query.select.where([:s, :p, :o]).group_digest(:s, '_', 1000, 1).to_s.should == "SELECT (sql:GROUP_DIGEST (?s, '_', 1000, 1 ) AS ?s) WHERE { ?s ?p ?o . }"
+      expect(subject.select.where([:s, :p, :o]).sum(:s).to_s).to eql "SELECT (SUM (?s) AS ?s) WHERE { ?s ?p ?o . }"
+      expect(subject.select.where([:s, :p, :o]).min(:s).to_s).to eql "SELECT (MIN (?s) AS ?s) WHERE { ?s ?p ?o . }"
+      expect(subject.select.where([:s, :p, :o]).max(:s).to_s).to eql "SELECT (MAX (?s) AS ?s) WHERE { ?s ?p ?o . }"
+      expect(subject.select.where([:s, :p, :o]).avg(:s).to_s).to eql "SELECT (AVG (?s) AS ?s) WHERE { ?s ?p ?o . }"
+      expect(subject.select.where([:s, :p, :o]).sample(:s).to_s).to eql "SELECT (sql:SAMPLE (?s) AS ?s) WHERE { ?s ?p ?o . }"
+      expect(subject.select.where([:s, :p, :o]).group_concat(:s, '_').to_s).to eql "SELECT (sql:GROUP_CONCAT (?s, '_' ) AS ?s) WHERE { ?s ?p ?o . }"
+      expect(subject.select.where([:s, :p, :o]).group_digest(:s, '_', 1000, 1).to_s).to eql "SELECT (sql:GROUP_DIGEST (?s, '_', 1000, 1 ) AS ?s) WHERE { ?s ?p ?o . }"
     end
 
     it "should support multiple instances of SAMPLE" do
-      @query.select.where([:s, :p, :o]).sample(:s).sample(:p).to_s.should == "SELECT (sql:SAMPLE (?s) AS ?s) (sql:SAMPLE (?p) AS ?p) WHERE { ?s ?p ?o . }"
+      expect(subject.select.where([:s, :p, :o]).sample(:s).sample(:p).to_s).to eql "SELECT (sql:SAMPLE (?s) AS ?s) (sql:SAMPLE (?p) AS ?p) WHERE { ?s ?p ?o . }"
     end
 
     it "should support multiple instances of MIN/MAX/AVG/SUM" do
-      @query.select.where([:s, :p, :o]).min(:s).min(:p).to_s.should == "SELECT (MIN (?s) AS ?s) (MIN (?p) AS ?p) WHERE { ?s ?p ?o . }"
-      @query.select.where([:s, :p, :o]).max(:s).max(:p).to_s.should == "SELECT (MAX (?s) AS ?s) (MAX (?p) AS ?p) WHERE { ?s ?p ?o . }"
-      @query.select.where([:s, :p, :o]).avg(:s).avg(:p).to_s.should == "SELECT (AVG (?s) AS ?s) (AVG (?p) AS ?p) WHERE { ?s ?p ?o . }"      
-      @query.select.where([:s, :p, :o]).sum(:s).sum(:p).to_s.should == "SELECT (SUM (?s) AS ?s) (SUM (?p) AS ?p) WHERE { ?s ?p ?o . }"      
+      expect(subject.select.where([:s, :p, :o]).min(:s).min(:p).to_s).to eql "SELECT (MIN (?s) AS ?s) (MIN (?p) AS ?p) WHERE { ?s ?p ?o . }"
+      expect(subject.select.where([:s, :p, :o]).max(:s).max(:p).to_s).to eql "SELECT (MAX (?s) AS ?s) (MAX (?p) AS ?p) WHERE { ?s ?p ?o . }"
+      expect(subject.select.where([:s, :p, :o]).avg(:s).avg(:p).to_s).to eql "SELECT (AVG (?s) AS ?s) (AVG (?p) AS ?p) WHERE { ?s ?p ?o . }"      
+      expect(subject.select.where([:s, :p, :o]).sum(:s).sum(:p).to_s).to eql "SELECT (SUM (?s) AS ?s) (SUM (?p) AS ?p) WHERE { ?s ?p ?o . }"      
     end
     
     it "should support multiple instances of GROUP_CONCAT" do
-      @query.select.where([:s, :p, :o]).group_concat(:s, '_').group_concat(:p, '-').to_s.should == "SELECT (sql:GROUP_CONCAT (?s, '_' ) AS ?s) (sql:GROUP_CONCAT (?p, '-' ) AS ?p) WHERE { ?s ?p ?o . }"
+      expect(subject.select.where([:s, :p, :o]).group_concat(:s, '_').group_concat(:p, '-').to_s).to eql "SELECT (sql:GROUP_CONCAT (?s, '_' ) AS ?s) (sql:GROUP_CONCAT (?p, '-' ) AS ?p) WHERE { ?s ?p ?o . }"
     end
 
     it "should support multiple instances of GROUP_DIGEST" do
-      @query.select.where([:s, :p, :o]).group_digest(:s, '_', 1000, 1).group_digest(:p, '-', 1000, 1).to_s.should == "SELECT (sql:GROUP_DIGEST (?s, '_', 1000, 1 ) AS ?s) (sql:GROUP_DIGEST (?p, '-', 1000, 1 ) AS ?p) WHERE { ?s ?p ?o . }"
+      expect(subject.select.where([:s, :p, :o]).group_digest(:s, '_', 1000, 1).group_digest(:p, '-', 1000, 1).to_s).to eql "SELECT (sql:GROUP_DIGEST (?s, '_', 1000, 1 ) AS ?s) (sql:GROUP_DIGEST (?p, '-', 1000, 1 ) AS ?p) WHERE { ?s ?p ?o . }"
     end
             
     it "should support aggregates in addition to SELECT variables" do
-      @query.select(:s).where([:s, :p, :o]).group_digest(:o, '_', 1000, 1).to_s.should == "SELECT (sql:GROUP_DIGEST (?o, '_', 1000, 1 ) AS ?o) ?s WHERE { ?s ?p ?o . }"
+      expect(subject.select(:s).where([:s, :p, :o]).group_digest(:o, '_', 1000, 1).to_s).to eql "SELECT (sql:GROUP_DIGEST (?o, '_', 1000, 1 ) AS ?o) ?s WHERE { ?s ?p ?o . }"
     end
 
     it "should support multiple instances of aggregates AND select variables" do
-      @query.select(:s).where([:s, :p, :o]).sample(:p).sample(:o).to_s.should == "SELECT (sql:SAMPLE (?p) AS ?p) (sql:SAMPLE (?o) AS ?o) ?s WHERE { ?s ?p ?o . }"
+      expect(subject.select(:s).where([:s, :p, :o]).sample(:p).sample(:o).to_s).to eql "SELECT (sql:SAMPLE (?p) AS ?p) (sql:SAMPLE (?o) AS ?o) ?s WHERE { ?s ?p ?o . }"
     end
         
     it "should support ORDER BY" do
-      @query.select.where([:s, :p, :o]).order_by(:o).to_s.should == "SELECT * WHERE { ?s ?p ?o . } ORDER BY ?o"
-      @query.select.where([:s, :p, :o]).order_by('?o').to_s.should == "SELECT * WHERE { ?s ?p ?o . } ORDER BY ?o"
-      # @query.select.where([:s, :p, :o]).order_by(:o => :asc).to_s.should == "SELECT * WHERE { ?s ?p ?o . } ORDER BY ?o ASC"
-      @query.select.where([:s, :p, :o]).order_by('ASC(?o)').to_s.should == "SELECT * WHERE { ?s ?p ?o . } ORDER BY ASC(?o)"
-      # @query.select.where([:s, :p, :o]).order_by(:o => :desc).to_s.should == "SELECT * WHERE { ?s ?p ?o . } ORDER BY ?o DESC"
-      @query.select.where([:s, :p, :o]).order_by('DESC(?o)').to_s.should == "SELECT * WHERE { ?s ?p ?o . } ORDER BY DESC(?o)"
+      expect(subject.select.where([:s, :p, :o]).order_by(:o).to_s).to eql "SELECT * WHERE { ?s ?p ?o . } ORDER BY ?o"
+      expect(subject.select.where([:s, :p, :o]).order_by('?o').to_s).to eql "SELECT * WHERE { ?s ?p ?o . } ORDER BY ?o"
+      # expect(subject.select.where([:s, :p, :o]).order_by(o: :asc).to_s).to eql "SELECT * WHERE { ?s ?p ?o . } ORDER BY ?o ASC"
+      expect(subject.select.where([:s, :p, :o]).order_by('ASC(?o)').to_s).to eql "SELECT * WHERE { ?s ?p ?o . } ORDER BY ASC(?o)"
+      # subject.select.where([:s, :p, :o]).order_by(o: :desc.to_s).to eql "SELECT * WHERE { ?s ?p ?o . } ORDER BY ?o DESC"
+      expect(subject.select.where([:s, :p, :o]).order_by('DESC(?o)').to_s).to eql "SELECT * WHERE { ?s ?p ?o . } ORDER BY DESC(?o)"
     end
 
     it "should support OFFSET" do
-      @query.select.where([:s, :p, :o]).offset(100).to_s.should == "SELECT * WHERE { ?s ?p ?o . } OFFSET 100"
+      expect(subject.select.where([:s, :p, :o]).offset(100).to_s).to eql "SELECT * WHERE { ?s ?p ?o . } OFFSET 100"
     end
 
     it "should support LIMIT" do
-      @query.select.where([:s, :p, :o]).limit(10).to_s.should == "SELECT * WHERE { ?s ?p ?o . } LIMIT 10"
+      expect(subject.select.where([:s, :p, :o]).limit(10).to_s).to eql "SELECT * WHERE { ?s ?p ?o . } LIMIT 10"
     end
 
     it "should support OFFSET with LIMIT" do
-      @query.select.where([:s, :p, :o]).offset(100).limit(10).to_s.should == "SELECT * WHERE { ?s ?p ?o . } OFFSET 100 LIMIT 10"
-      @query.select.where([:s, :p, :o]).slice(100, 10).to_s.should == "SELECT * WHERE { ?s ?p ?o . } OFFSET 100 LIMIT 10"
+      expect(subject.select.where([:s, :p, :o]).offset(100).limit(10).to_s).to eql "SELECT * WHERE { ?s ?p ?o . } OFFSET 100 LIMIT 10"
+      expect(subject.select.where([:s, :p, :o]).slice(100, 10).to_s).to eql "SELECT * WHERE { ?s ?p ?o . } OFFSET 100 LIMIT 10"
     end
 
 #  DEPRECATED - USE RDF::Vocabulary instead
 =begin
     it "should support PREFIX" do
       prefixes = ["dc: <http://purl.org/dc/elements/1.1/>", "foaf: <http://xmlns.com/foaf/0.1/>"]
-      @query.select.prefix(prefixes[0]).prefix(prefixes[1]).where([:s, :p, :o]).to_s.should ==
+      subject.select.prefix(prefixes[0]).prefix(prefixes[1]).where([:s, :p, :o].to_s).to eql
         "PREFIX #{prefixes[0]} PREFIX #{prefixes[1]} SELECT * WHERE { ?s ?p ?o . }"
     end
 
     it "constructs PREFIXes" do
-      prefixes = RDF::Virtuoso::Prefixes.new dc: RDF::DC, foaf: RDF::FOAF
-      @query.select.prefixes(prefixes).where([:s, :p, :o]).to_s.should ==
-        "PREFIX dc: <#{RDF::DC}> PREFIX foaf: <#{RDF::FOAF}> SELECT * WHERE { ?s ?p ?o . }"
+      prefixes = RDF::Virtuoso::Prefixes.new dc: RDF::Vocab::DC, foaf: RDF::FOAF
+      subject.select.prefixes(prefixes).where([:s, :p, :o].to_s).to eql
+        "PREFIX dc: <#{RDF::Vocab::DC}> PREFIX foaf: <#{RDF::FOAF}> SELECT * WHERE { ?s ?p ?o . }"
     end
 
     it "should support custom PREFIXes in hash array" do
       prefixes = RDF::Virtuoso::Prefixes.new foo: "http://foo.com/", bar: "http://bar.net"
-      @query.select.prefixes(prefixes).where([:s, :p, :o]).to_s.should ==
+      subject.select.prefixes(prefixes).where([:s, :p, :o].to_s).to eql
         "PREFIX foo: <http://foo.com/> PREFIX bar: <http://bar.net> SELECT * WHERE { ?s ?p ?o . }"
     end
 
     it "should support accessing custom PREFIXes in SELECT" do
       prefixes = RDF::Virtuoso::Prefixes.new foo: "http://foo.com/"
-      @query.select.where(['foo:bar', :p, :o]).prefixes(prefixes).to_s.should ==
+      subject.select.where(['foo:bar', :p, :o]).prefixes(prefixes.to_s).to eql
         "PREFIX foo: <http://foo.com/bar> SELECT * WHERE { ?s ?p ?o . }"
     end
 =end  
 
     it "should support using custom RDF::Vocabulary prefixes" do
       BIBO = RDF::Vocabulary.new("http://purl.org/ontology/bibo/")
-      @query.select.where([:s, :p, BIBO.Document]).to_s.should ==
+      expect(subject.select.where([:s, :p, BIBO.Document]).to_s).to eql(
         "SELECT * WHERE { ?s ?p <http://purl.org/ontology/bibo/Document> . }"
+      )
     end
     
     it "should support OPTIONAL" do
-      @query.select.where([:s, :p, :o]).optional([:s, RDF.type, :o], [:s, RDF::DC.abstract, :o]).to_s.should ==
-        "SELECT * WHERE { ?s ?p ?o . OPTIONAL { ?s <#{RDF.type}> ?o . ?s <#{RDF::DC.abstract}> ?o . } }"
+      expect(subject.select.where([:s, :p, :o]).optional([:s, RDF.type, :o], [:s, RDF::Vocab::DC.abstract, :o]).to_s).to eql(
+        "SELECT * WHERE { ?s ?p ?o . OPTIONAL { ?s <#{RDF.type}> ?o . ?s <#{RDF::Vocab::DC.abstract}> ?o . } }"
+      )
     end
 
-    it "should support OPTIONAL with GRAPH contexts" do
-      @graph1 = "http://example1.org/"
-      @graph2 = "http://example2.org/"
-      @query.select.where([:s, :p, :o, :context => @graph1]).optional([:s, RDF.type, RDF::DC.BibliographicResource, :context => @graph2]).to_s.should == 
-        "SELECT * WHERE { GRAPH <#{@graph1}> { ?s ?p ?o . } OPTIONAL { GRAPH <#{@graph2}> { ?s <#{RDF.type}> <#{RDF::DC.BibliographicResource}> . } } }"
+    it "should support OPTIONAL with GRAPH names" do
+      graph1 = "http://example1.org/"
+      graph2 = "http://example2.org/"
+      expect(subject.select.where([:s, :p, :o, graph_name: graph1]).optional([:s, RDF.type, RDF::Vocab::DC.BibliographicResource, graph_name: graph2]).to_s).to eql(
+        "SELECT * WHERE { GRAPH <#{graph1}> { ?s ?p ?o . } OPTIONAL { GRAPH <#{graph2}> { ?s <#{RDF.type}> <#{RDF::Vocab::DC.BibliographicResource}> . } } }"
+      )
     end
     
     it "should support multiple OPTIONALs" do
-      @query.select.where([:s, :p, :o]).optional([:s, RDF.type, :o]).optional([:s, RDF::DC.abstract, :o]).to_s.should ==
-        "SELECT * WHERE { ?s ?p ?o . OPTIONAL { ?s <#{RDF.type}> ?o . } OPTIONAL { ?s <#{RDF::DC.abstract}> ?o . } }"
+      expect(subject.select.where([:s, :p, :o]).optional([:s, RDF.type, :o]).optional([:s, RDF::Vocab::DC.abstract, :o]).to_s).to eql(
+        "SELECT * WHERE { ?s ?p ?o . OPTIONAL { ?s <#{RDF.type}> ?o . } OPTIONAL { ?s <#{RDF::Vocab::DC.abstract}> ?o . } }"
+      )
     end
 
     it "should support MINUS, also with an array pattern" do
-      @query.select.where([:s, :p, :o]).minus([:s, RDF.type, :o], [:s, RDF::DC.abstract, :o]).to_s.should ==
-        "SELECT * WHERE { ?s ?p ?o . MINUS { ?s <#{RDF.type}> ?o . ?s <#{RDF::DC.abstract}> ?o . } }"
+      expect(subject.select.where([:s, :p, :o]).minus([:s, RDF.type, :o], [:s, RDF::Vocab::DC.abstract, :o]).to_s).to eql(
+        "SELECT * WHERE { ?s ?p ?o . MINUS { ?s <#{RDF.type}> ?o . ?s <#{RDF::Vocab::DC.abstract}> ?o . } }"
+      )
     end
 
     it "should support multiple MINUSes" do
-      @query.select.where([:s, :p, :o]).minus([:s, RDF.type, :o]).minus([:s, RDF::DC.abstract, :o]).to_s.should ==
-        "SELECT * WHERE { ?s ?p ?o . MINUS { ?s <#{RDF.type}> ?o . } MINUS { ?s <#{RDF::DC.abstract}> ?o . } }"
+      expect(subject.select.where([:s, :p, :o]).minus([:s, RDF.type, :o]).minus([:s, RDF::Vocab::DC.abstract, :o]).to_s).to eql(
+        "SELECT * WHERE { ?s ?p ?o . MINUS { ?s <#{RDF.type}> ?o . } MINUS { ?s <#{RDF::Vocab::DC.abstract}> ?o . } }"
+      )
     end
 
-    it "should support MINUS with a GRAPH context" do
-      @graph1 = "http://example1.org/"
-      @query.select.where([:s, :p, :o]).minus([:s, RDF.type, :o, :context => @graph1]).to_s.should ==
-        "SELECT * WHERE { ?s ?p ?o . MINUS { GRAPH <#{@graph1}> { ?s <#{RDF.type}> ?o . } } }"
+    it "should support MINUS with a GRAPH name" do
+      graph1 = "http://example1.org/"
+      expect(subject.select.where([:s, :p, :o]).minus([:s, RDF.type, :o, graph_name: graph1]).to_s).to eql(
+        "SELECT * WHERE { ?s ?p ?o . MINUS { GRAPH <#{graph1}> { ?s <#{RDF.type}> ?o . } } }"
+      )
     end
         
     it "should support UNION" do
-      @query.select.where([:s, RDF::DC.abstract, :o]).union([:s, RDF.type, :o]).to_s.should ==
-      "SELECT * WHERE { { ?s <#{RDF::DC.abstract}> ?o . } UNION { ?s <#{RDF.type}> ?o . } }"
+      expect(subject.select.where([:s, RDF::Vocab::DC.abstract, :o]).union([:s, RDF.type, :o]).to_s).to eql(
+        "SELECT * WHERE { { ?s <#{RDF::Vocab::DC.abstract}> ?o . } UNION { ?s <#{RDF.type}> ?o . } }"
+      )
     end
 
     it "should support FILTER" do
-      @query.select.where([:s, RDF::DC.abstract, :o]).filter('lang(?text) != "nb"').to_s.should ==
-      "SELECT * WHERE { ?s <#{RDF::DC.abstract}> ?o . FILTER(lang(?text) != \"nb\") }"
+      expect(subject.select.where([:s, RDF::Vocab::DC.abstract, :o]).filter('lang(?text) != "nb"').to_s).to eql(
+        "SELECT * WHERE { ?s <#{RDF::Vocab::DC.abstract}> ?o . FILTER(lang(?text) != \"nb\") }"
+      )
     end
 
     it "should support multiple FILTERs" do
       filters = ['lang(?text) != "nb"', 'regex(?uri, "^https")']
-      @query.select.where([:s, RDF::DC.abstract, :o]).filters(filters).to_s.should ==
-      "SELECT * WHERE { ?s <#{RDF::DC.abstract}> ?o . FILTER(lang(?text) != \"nb\") FILTER(regex(?uri, \"^https\")) }"
+      expect(subject.select.where([:s, RDF::Vocab::DC.abstract, :o]).filters(filters).to_s).to eql(
+        "SELECT * WHERE { ?s <#{RDF::Vocab::DC.abstract}> ?o . FILTER(lang(?text) != \"nb\") FILTER(regex(?uri, \"^https\")) }"
+      )
     end
 
     it "should support DEFINE headers in queries" do
       define = 'sql:select-option "ORDER"'
-      @query.select.where([:s, RDF::DC.abstract, :o]).define(define).to_s.should ==
-      "DEFINE #{define} SELECT * WHERE { ?s <#{RDF::DC.abstract}> ?o . }"
+      expect(subject.select.where([:s, RDF::Vocab::DC.abstract, :o]).define(define).to_s).to eql(
+        "DEFINE #{define} SELECT * WHERE { ?s <#{RDF::Vocab::DC.abstract}> ?o . }"
+      )
     end
 
     it "should support grouping graph patterns within brackets" do
-      @query.select.where.group([:s, :p, :o],[:s2, :p2, :o2]).
-        where([:s3, :p3, :o3]).to_s.should ==
-      "SELECT * WHERE { { ?s ?p ?o . ?s2 ?p2 ?o2 . } ?s3 ?p3 ?o3 . }"
+      expect(subject.select.where.group([:s, :p, :o],[:s2, :p2, :o2]).
+      where([:s3, :p3, :o3]).to_s).to eql(
+        "SELECT * WHERE { { ?s ?p ?o . ?s2 ?p2 ?o2 . } ?s3 ?p3 ?o3 . }"
+      )
     end
 
     it "should support grouping with several graph statements" do
-      @query.select.where.graph2(RDF::URI.new("a")).group([:s, :p, :o],[:s2, :p2, :o2]).
-        where.graph2(RDF::URI.new("b")).group([:s3, :p3, :o3]).to_s.should ==
+      expect(subject.select.where.graph2(RDF::URI.new("a")).group([:s, :p, :o],[:s2, :p2, :o2]).
+      where.graph2(RDF::URI.new("b")).group([:s3, :p3, :o3]).to_s).to eql(
         "SELECT * WHERE { GRAPH <a> { ?s ?p ?o . ?s2 ?p2 ?o2 . } GRAPH <b> { ?s3 ?p3 ?o3 . } }"
+      )
     end
 
   end
 
   context "when building DESCRIBE queries" do
     it "should support basic graph patterns" do
-      @query.describe.where([:s, :p, :o]).to_s.should == "DESCRIBE * WHERE { ?s ?p ?o . }"
+      expect(subject.describe.where([:s, :p, :o]).to_s).to eql "DESCRIBE * WHERE { ?s ?p ?o . }"
     end
 
     it "should support projection" do
-      @query.describe(:s).where([:s, :p, :o]).to_s.should == "DESCRIBE ?s WHERE { ?s ?p ?o . }"
-      @query.describe(:s, :p).where([:s, :p, :o]).to_s.should == "DESCRIBE ?s ?p WHERE { ?s ?p ?o . }"
-      @query.describe(:s, :p, :o).where([:s, :p, :o]).to_s.should == "DESCRIBE ?s ?p ?o WHERE { ?s ?p ?o . }"
+      expect(subject.describe(:s).where([:s, :p, :o]).to_s).to eql "DESCRIBE ?s WHERE { ?s ?p ?o . }"
+      expect(subject.describe(:s, :p).where([:s, :p, :o]).to_s).to eql "DESCRIBE ?s ?p WHERE { ?s ?p ?o . }"
+      expect(subject.describe(:s, :p, :o).where([:s, :p, :o]).to_s).to eql "DESCRIBE ?s ?p ?o WHERE { ?s ?p ?o . }"
     end
 
     it "should support RDF::URI arguments" do
       uris = ['http://www.bbc.co.uk/programmes/b007stmh#programme', 'http://www.bbc.co.uk/programmes/b00lg2xb#programme']
-      @query.describe(RDF::URI.new(uris[0]),RDF::URI.new(uris[1])).to_s.should ==
+      expect(subject.describe(RDF::URI.new(uris[0]),RDF::URI.new(uris[1])).to_s).to eql(
         "DESCRIBE <#{uris[0]}> <#{uris[1]}>"
+      )
     end
   end
 
   context "when building CONSTRUCT queries" do
     it "should support basic graph patterns" do
-      @query.construct([:s, :p, :o]).where([:s, :p, :o]).to_s.should == "CONSTRUCT { ?s ?p ?o . } WHERE { ?s ?p ?o . }"
+      expect(subject.construct([:s, :p, :o]).where([:s, :p, :o]).to_s).to eql "CONSTRUCT { ?s ?p ?o . } WHERE { ?s ?p ?o . }"
     end
 
     it "should support complex constructs" do
-      @query.construct([:s, :p, :o], [:s, :q, RDF::Literal.new("new")]).where([:s, :p, :o], [:s, :q, "old"]).to_s.should == "CONSTRUCT { ?s ?p ?o . ?s ?q \"new\" . } WHERE { ?s ?p ?o . ?s ?q \"old\" . }"
+      expect(subject.construct([:s, :p, :o], [:s, :q, RDF::Literal.new("new")]).where([:s, :p, :o], [:s, :q, "old"]).to_s).to eql "CONSTRUCT { ?s ?p ?o . ?s ?q \"new\" . } WHERE { ?s ?p ?o . ?s ?q \"old\" . }"
     end    
           
 

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -2,39 +2,35 @@ $:.unshift "."
 require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'rdf/spec/repository'
 
-describe RDF::Virtuoso::Repository do
+#require_relative '../lib/rdf/virtuoso/repository'
 
-  before(:each) do
-    @uri = "http://localhost:8890/sparql"
-    @update_uri = "http://localhost:8890/sparql-auth"
-    @repository = RDF::Virtuoso::Repository.new(@uri)
+describe RDF::Virtuoso::Repository do
+  let(:uri) {"http://localhost:8890/sparql"}
+  let(:update_uri) {"http://localhost:8890/sparql-auth"}
+  let(:repo) {RDF::Virtuoso::Repository.new(uri)}
+
+  #include RDF_Repository  # not implemented
+    
+  it "should support connecting to a Virtuoso SPARQL endpoint" do
+    expect(repo.instance_variable_get("@sparul_endpoint")).to eql "/sparql"
+  end
+
+  it "should support accept port in repository endpoint" do
+    expect(repo.instance_variable_get("@base_uri")).to eql "http://localhost:8890"
+  end
+      
+  it "should support connecting to a Virtuoso SPARUL endpoint with BASIC AUTH" do
+    repo = RDF::Virtuoso::Repository.new(uri, update_uri: update_uri, username: 'admin', password: 'secret', auth_method: 'basic')
+    expect(repo.instance_variable_get("@auth_method")).to eql "basic"
   end
   
-    #include RDF_Repository  # not implemented
-      
-    it "should support connecting to a Virtuoso SPARQL endpoint" do
-      repo = RDF::Virtuoso::Repository.new(@uri)
-      repo.instance_variable_get("@sparul_endpoint").should == "/sparql"
-    end
-
-    it "should support accept port in repository endpoint" do
-      repo = RDF::Virtuoso::Repository.new(@uri)
-      repo.instance_variable_get("@base_uri").should == "http://localhost:8890"
-    end
-        
-    it "should support connecting to a Virtuoso SPARUL endpoint with BASIC AUTH" do
-      repo = RDF::Virtuoso::Repository.new(@uri, :update_uri => @update_uri, :username => 'admin', :password => 'secret', :auth_method => 'basic')
-      repo.instance_variable_get("@auth_method").should == "basic"
-    end
-    
-    it "should support connecting to a Virtuoso SPARUL endpoint with DIGEST AUTH" do
-      repo = RDF::Virtuoso::Repository.new(@uri, :update_uri => @update_uri, :username => 'admin', :password => 'secret', :auth_method => 'digest')
-      repo.instance_variable_get("@sparul_endpoint").should == "/sparql-auth"
-    end
-    
-    it "should support timeout option" do
-      repo = RDF::Virtuoso::Repository.new(@uri, :timeout => 10)
-      repo.instance_variable_get("@timeout").should == 10
-    end
-    
-end
+  it "should support connecting to a Virtuoso SPARUL endpoint with DIGEST AUTH" do
+    repo = RDF::Virtuoso::Repository.new(uri, update_uri: update_uri, username: 'admin', password: 'secret', auth_method: 'digest')
+    expect(repo.instance_variable_get("@sparul_endpoint")).to eql "/sparql-auth"
+  end
+  
+  it "should support timeout option" do
+    repo = RDF::Virtuoso::Repository.new(uri, timeout: 10)
+    expect(repo.instance_variable_get("@timeout")).to eql 10
+  end
+ end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'rdf'
 require 'rdf/spec'
 require 'rdf/spec/matchers'
 require 'rdf/virtuoso'
+require 'rdf/vocab'
 
 RSpec.configure do |config|
   config.include(RDF::Spec::Matchers)


### PR DESCRIPTION
Use graph_name instead of context for RDF.rb 1.99.

Blind changes, as I don't have it running locally, but these will be necessary to keep up for RDF.rb 1.99 and 2.0.